### PR TITLE
Correcting error in documentation (inversion of two default colors)

### DIFF
--- a/snaptodo.tex
+++ b/snaptodo.tex
@@ -90,7 +90,7 @@
 	The color of the broken line is
 	{\ttfamily\verb|snaptodo@chain|}.
 	The default color for that is
-	{\ttfamily\verb|red!50!black|}.
+	{\ttfamily\verb|yellow!50!black|}.
 	Saying
 	{\ttfamily\verb|\colorlet{snaptodo@chain}{green!50!white}|}
 	lets you to change this color globally.  On the other hand,
@@ -101,7 +101,7 @@
 	The color of the note text is
 	{\ttfamily\verb|snaptodo@block|}.
 	The default color for that is
-	{\ttfamily\verb|yellow!50!black|}.
+	{\ttfamily\verb|red!50!black|}.
 	Saying
 	{\ttfamily\verb|\colorlet{snaptodo@block}{blue!50!white}|}
 	lets you change this color.  On the other hand,


### PR DESCRIPTION
The doc say that default color for `snaptodo@chain` is `red!50!black`. No, it's `yellow!50!black` (line 140 of https://github.com/Symbol1/snaptodo/blob/main/snaptodo.sty).

The doc say that default color for `snaptodo@block` is `yellow!50!black`. No, it's `red!50!black` (line 141 of https://github.com/Symbol1/snaptodo/blob/main/snaptodo.sty).